### PR TITLE
add test: TestSecondRequest

### DIFF
--- a/handle_test.go
+++ b/handle_test.go
@@ -6,12 +6,12 @@ import (
 	"time"
 )
 
-type addArgs struct {
-	X int `json:"x"`
-	Y int `json:"y"`
-}
-
 func TestSimpleFunction(t *testing.T) {
+	type addArgs struct {
+		X int `json:"x"`
+		Y int `json:"y"`
+	}
+
 	done := make(chan bool, 1)
 	errors := make(chan error, 1)
 
@@ -41,4 +41,51 @@ func TestSimpleFunction(t *testing.T) {
 	case err := <-errors:
 		t.Fatal(err)
 	}
+}
+
+func TestSecondRequest(t *testing.T) {
+	type data struct {
+		X string `json:"x"`
+	}
+	handlerTakes := 3 * time.Second
+	epsilon := 100 * time.Millisecond
+	go func() {
+		err := Handle(func(args *data) *data {
+			t.Logf("Handling %+v (takes %s)", args, handlerTakes)
+			time.Sleep(handlerTakes)
+			return args
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	call1Done := make(chan interface{}, 1)
+	t.Logf("1st call begins in background, this should pass")
+	go func() {
+		res, err := Call("localhost", data{X: "shouldPass"})
+		if err != nil {
+			t.Fatal(err)
+
+		}
+		call1Done <- res
+	}()
+	t.Logf("sleeping for %s, so that make sure the 1st call request is received", epsilon)
+	time.Sleep(epsilon)
+
+	t.Logf("2nd call begins in foreground, this should fail immediately")
+	call2Begin := time.Now()
+	res, err := Call("localhost", data{X: "call2"})
+	if err == nil {
+		t.Fatal("2nd call should fail, got %v", res)
+	}
+	call2Took := time.Now().Sub(call2Begin)
+	t.Logf("2nd call took %s, got err %v", call2Took, err)
+	if call2Took > epsilon {
+		t.Fatalf("2nd call should have failed immediately (%s), took %s",
+			epsilon, call2Took)
+	}
+
+	res = <-call1Done
+	t.Logf("1st call done, got %+v", res)
 }


### PR DESCRIPTION
For #2 

The test passes with #2 
```
=== RUN   TestSecondRequest
--- PASS: TestSecondRequest (3.00s)
        handle_test.go:64: 1st call begins in background, this should pass
        handle_test.go:73: sleeping for 100ms, so that make sure the 1st call request is received
        handle_test.go:54: Handling &{X:shouldPass} (takes 3s)
        handle_test.go:76: 2nd call begins in foreground, this should fail immediately
        handle_test.go:83: 2nd call took 486.586µs, got err dial tcp 127.0.0.1:9999: getsockopt: connection refused
        handle_test.go:90: 1st call done, got map[x:shouldPass]
PASS
```

But it fails without #2 
```
=== RUN   TestSecondRequest
--- FAIL: TestSecondRequest (3.00s)
        handle_test.go:64: 1st call begins in background, this should pass
        handle_test.go:73: sleeping for 100ms, so that make sure the 1st call request is received
        handle_test.go:54: Handling &{X:shouldPass} (takes 3s)
        handle_test.go:76: 2nd call begins in foreground, this should fail immediately
        handle_test.go:83: 2nd call took 2.900976307s, got err read tcp 127.0.0.1:40396->127.0.0.1:9999: read: connection reset by peer
        handle_test.go:86: 2nd call should have failed immediately (100ms), took 2.900976307s
FAIL
```

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>