### PR TITLE
call.go: set TCP keepalive as a workaround for docker/docker#29655

### DIFF
--- a/call.go
+++ b/call.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net"
+	"time"
 )
 
 // Call a Funker function
@@ -20,6 +21,17 @@ func Call(name string, args interface{}) (interface{}, error) {
 
 	conn, err := net.DialTCP("tcp", nil, addr)
 	if err != nil {
+		return nil, err
+	}
+	// Keepalive is a workaround for docker/docker#29655 .
+	// The implementation of FIN_WAIT2 seems weird on Swarm-mode.
+	// It seems always refuseing any packet after 60 seconds.
+	//
+	// TODO: remove this workaround if the issue gets resolved on the Docker side
+	if err := conn.SetKeepAlive(true); err != nil {
+		return nil, err
+	}
+	if err := conn.SetKeepAlivePeriod(30 * time.Second); err != nil {
 		return nil, err
 	}
 	if _, err = conn.Write(argsJSON); err != nil {


### PR DESCRIPTION
In Swarm-mode, any TCP packet after staying 60 seconds at the FIN_WAIT2
state seems rejected. (docker/docker#29655)

This commit enables 30-second TCP keepalive so as to avoid the issue.

This workaround code should be removed when the issue gets resolved on the
Docker side.


#### Test

No UT is added to this PR, but an integration test is available at https://github.com/AkihiroSuda/demo-funker-issue/commits/workaround-tcp-keepalive

![image](https://cloud.githubusercontent.com/assets/9248427/21479294/68b5c5a4-cb96-11e6-9a46-9ab4794d25b6.png)

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>